### PR TITLE
Transition to the official dependabot implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Basically this is to move to the official github dependabot implementation. If not already created, it will need a pr label `dependencies`.