### PR TITLE
➕Add 1/1000 chance for coin to land on side

### DIFF
--- a/lib/cogs/fun.py
+++ b/lib/cogs/fun.py
@@ -1,4 +1,4 @@
-from random import choice, randint
+from random import choice, randint, random
 from typing import Optional
 from aiohttp import request
 from datetime import datetime
@@ -996,7 +996,10 @@ class Fun(Cog):
 
     @command(name="coinflip", aliases=["cf"], brief="Flip a coin")
     async def coin_flip_command(self, ctx):
-        await ctx.reply(choice(("Heads!", "Tails!")))
+        if random() > 0.001:
+            await ctx.reply(choice(("Heads!", "Tails!")))
+        else:
+            await ctx.reply("The coin landed on its side...")
 
     @Cog.listener()
     async def on_ready(self):


### PR DESCRIPTION
> the coin flip command now has a 1/1000 chance of landing on its side. pain peko.

closes #185, i guess

basically, generate a random float, if said float is less than [or equal to] 0.001, send "The coin landed on its side..."

i think it works. i'm 515 flips in and i still haven't gotten the message yet...
try at your own risk :3