### PR TITLE
➕Add amount of xp needed to next level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.8.5
+* Added "xp to next level" to `d!level` [(#221)](https://github.com/DoobDev/Doob/issues/221)
+
 ## v2.8.4
 * Added who made the link to short link logs ([#209](https://github.com/doobdev/Doob/issues/209))
 * Added end poll command (d!endpoll) ([#212](https://github.com/doobdev/Doob/issues/212))

--- a/launcher.py
+++ b/launcher.py
@@ -1,5 +1,5 @@
 from lib.bot import bot
 
-VERSION = "2.8.4"
+VERSION = "2.8.5"
 
 bot.run(VERSION)

--- a/lib/cogs/exp.py
+++ b/lib/cogs/exp.py
@@ -175,8 +175,9 @@ class Exp(Cog):
         )
 
         if lvl is not None:
+            to_next_level = int((lvl + 1) ** (20 / 11) * 42) - xp
             await ctx.reply(
-                f"`Global Rank:`\n{target.display_name} is level {lvl:,} with {xp:,} xp and is rank {ids.index(target.id)+1} of {len(ids):,} users globally.\n`Server Rank:`\n{target.display_name} is server level {lvl_g:,} with {xp_g:,} server xp."
+                f"`Global Rank:`\n{target.display_name} is level {lvl:,} with {xp:,} xp ({to_next_level:,} xp to next level) and is rank {ids.index(target.id)+1:,} of {len(ids):,} users globally.\n`Server Rank:`\n{target.display_name} is server level {lvl_g:,} with {xp_g:,} server xp."
             )
 
         else:


### PR DESCRIPTION
Some math:
![image](https://user-images.githubusercontent.com/25379179/120858218-7d967500-c550-11eb-8b2b-e367e6282b2c.png)
...which translates into Python like:
```py
exp = lvl ** (20 / 11) * 42
```
I have added this equation (using `lvl + 1`, and subtracting the user's current xp) to get the xp they need to advance to the next level. Given that the original xp equation however uses rounding, this may be... a bit inaccurate. I don't know by how much... but... ¯\\\_(ツ)_/¯ (please test!)

`20 / 11` doesn't calculate into a nice number (`1.818181818...`), and I have no idea how this actually affects performance.

I also don't really know how to implement this, but... eh.
Should resolve #221.